### PR TITLE
Add tests via nix flake checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,4 +14,4 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v3
       - name: Run nix flake checks
-        run: nix flake check --all-systems --verbose -L
+        run: nix flake check --all-systems -L

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,12 @@
     nixosModules = import ./nixos-modules { overlays = overlayList; };
 
     checks = forEachSystem (system: {
+      # see: https://blog.thalheim.io/2023/01/08/how-to-execute-nixos-tests-interactively-for-debugging/
+      # can run this test interactively by:
+      # `nix run .#checks.x86_64-linux.moduleTest.driver -- --interactive`
+      # then after being dropped into python shell:
+      # >>> machine1.wait_for_unit("default.target")
+      # >>> machine1.shell_interact()
       moduleTest = nixpkgs.legacyPackages.${system}.testers.runNixOSTest {
         name = "moduleTest";
         nodes.machine1 = {


### PR DESCRIPTION
right now it seems that the moduleTest is not actually getting the docker image to run. Here is some output from within the vm that is created by the test:

```
### running the test interactively
$ nix run .#check.x86_64-linux.moduleTest.driver -- --interactive
# now in python shell
>>> machine1.wait_for_unit("default.target")
>>> machine1.shell_interact()
# now will be in bash shell
```
```
$ docker ps
CONTAINER ID   IMAGE     COMMAND   CREATED   STATUS    PORTS     NAMES
$ journalctl -u managed-docker-compose.service
Jan 19 22:29:14 machine1 systemd[1]: Started Update Docker Compose files as part of nix config.
Jan 19 22:29:14 machine1 docker-compose-update.sh[676]: Running docker compose script using podman
Jan 19 22:29:15 machine1 podman[697]: 2025-01-19 22:29:15.664567562 +0000 UTC m=+0.582825192 system refresh
Jan 19 22:29:15 machine1 docker-compose-update.sh[676]: Loading: /nix/store/pjxhrivxy1ya6s3lqkcyxgbxnkmycgar-etc-docker-compose-hello-docker-compose.yaml
Jan 19 22:29:15 machine1 docker-compose-update.sh[852]: >>>> Executing external compose provider "/nix/store/aljdipyih6xcinj2m0yc7i40x76124wq-podman-compose-1.2.0/bin/podman-compose". Please see podman-compose(1) for how to disable this message. <<<<
Jan 19 22:29:16 machine1 podman[889]: 2025-01-19 22:29:16.75534111 +0000 UTC m=+0.082781192 pod create cd8d3bc97b1b0ba52f452d09b5b1d37966ac6b97dc35b67965a57cf1e4c496fc (image=, name=pod_store)
Jan 19 22:29:16 machine1 docker-compose-update.sh[852]: 
Jan 19 22:29:16 machine1 docker-compose-update.sh[889]: cd8d3bc97b1b0ba52f452d09b5b1d37966ac6b97dc35b67965a57cf1e4c496fc
Jan 19 22:29:16 machine1 docker-compose-update.sh[912]: Error: open /etc/containers/policy.json: no such file or directory
Jan 19 22:29:16 machine1 podman[912]: 2025-01-19 22:29:16.954881834 +0000 UTC m=+0.028875459 image pull-error  docker.io/alpine:latest open /etc/containers/policy.json: no such file or directory
Jan 19 22:29:17 machine1 docker-compose-update.sh[918]: Error: no container with name or ID "store_myservice_1" found: no such container
Jan 19 22:29:17 machine1 systemd[1]: managed-docker-compose.service: Deactivated successfully.
Jan 19 22:29:17 machine1 systemd[1]: managed-docker-compose.service: Consumed 646ms CPU time, 67.5M memory peak, 268K written to disk.
```
