### PR TITLE
Explicitly pass paths to Docker Compose files

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,25 +22,47 @@
 
     nixosModules = import ./nixos-modules { overlays = overlayList; };
 
-    checks = forEachSystem (system: {
+    checks = forEachSystem (system: 
+    let 
+      runTest = nixpkgs.legacyPackages.${system}.testers.runNixOSTest;
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
       # To run the tests: nix flake check --all-systems
       # You may also want the -L and --verbose flags for additional debugging.
-      dockerTest = nixpkgs.legacyPackages.${system}.testers.runNixOSTest {
+      dockerTest = runTest {
         name = "dockerTest";
         nodes.machine = {
           imports = [ self.outputs.nixosModules.managed-docker-compose ];
 
           # enable our custom module
           services.managed-docker-compose.enable = true;
+
+          services.managed-docker-compose.applications.test_app = {
+            compose_file = "/etc/docker-compose/test/compose.yaml";
+          };
+
+          # Create a fake Docker image that we can "run"
+          systemd.services.create-fake-docker-image = {
+            description = "Create fake Docker image";
+            before = [ "managed-docker-compose.service" ];
+            requiredBy = [ "managed-docker-compose.service" ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = "/bin/sh -c '${pkgs.gnutar}/bin/tar cv --files-from /dev/null | ${pkgs.docker}/bin/docker import - testimg'";
+              TimeoutSec = 90;
+            };
+          };
+
           virtualisation.oci-containers.backend = "docker";
 
           # Run a very lightweight image, but also one that doesn't immediately exit.
-          environment.etc."docker-compose/test/docker-compose.yaml".text = 
+          environment.etc."docker-compose/test/compose.yaml".text = 
             ''
             services:
               myservice:
                 image: testimg
                 command: /bin/tail -f /dev/null
+                network_mode: none
                 volumes:
                   # Map the bin from the current system in so that we can execute `tail`
                   - /nix/store:/nix/store
@@ -48,15 +70,11 @@
             '';
         };
         testScript = ''
-          machine.wait_for_unit("managed-docker-compose.service")
-          
-          # Create a fake image to run
-          machine.succeed("tar cv --files-from /dev/null | docker import - testimg")
           machine.wait_until_succeeds("docker ps --format='{{ .Image }}' | grep 'testimg'")
         '';
       };
 
-      podmanTest = nixpkgs.legacyPackages.${system}.testers.runNixOSTest {
+      podmanTest = runTest {
         name = "podmanTest";
         nodes.machine = {
           imports = [ self.outputs.nixosModules.managed-docker-compose ];
@@ -64,13 +82,30 @@
           # enable our custom module
           services.managed-docker-compose.enable = true;
 
+          services.managed-docker-compose.applications.test_app = {
+            compose_file = "/etc/docker-compose/test/compose.yaml";
+          };
+
+          # Create a fake Docker image that we can "run"
+          systemd.services.create-fake-docker-image = {
+            description = "Create fake Docker image";
+            before = [ "managed-docker-compose.service" ];
+            requiredBy = [ "managed-docker-compose.service" ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = "/bin/sh -c '${pkgs.gnutar}/bin/tar cv --files-from /dev/null | ${pkgs.podman}/bin/podman import - testimg'";
+              TimeoutSec = 90;
+            };
+          };
+
           # Run a very lightweight image, but also one that doesn't immediately exit.
-          environment.etc."docker-compose/test/docker-compose.yaml".text = 
+          environment.etc."docker-compose/test/compose.yaml".text = 
             ''
             services:
               myservice:
                 image: testimg
                 command: /bin/tail -f /dev/null
+                network_mode: none
                 volumes:
                   # Map the bin from the current system in so that we can execute `tail`
                   - /nix/store:/nix/store
@@ -78,11 +113,95 @@
             '';
         };
         testScript = ''
-          machine.wait_for_unit("managed-docker-compose.service")
-          
-          # Create a fake image to run
-          machine.succeed("tar cv --files-from /dev/null | podman import - testimg")
           machine.wait_until_succeeds("podman ps --format='{{ .Image }}' | grep 'testimg'")
+        '';
+      };
+
+      deactivateTest = runTest {
+        name = "deactivateOldComposeFilesTest";
+        nodes.machine = {
+          imports = [ self.outputs.nixosModules.managed-docker-compose ];
+
+          # enable our custom module
+          services.managed-docker-compose.enable = true;
+
+          # Use docker and not podman for this test
+          virtualisation.oci-containers.backend = "docker";
+
+          environment.systemPackages = with pkgs; [
+            docker
+            gnutar
+          ];
+
+          services.managed-docker-compose.applications.test_app = {
+            compose_file = "/etc/docker-compose/current_app/compose.yaml";
+          };
+
+          # Create a fake Docker image that we can "run"
+          systemd.services.create-fake-docker-image = {
+            description = "Create fake Docker image";
+            before = [ "managed-docker-compose.service" ];
+            requiredBy = [ "managed-docker-compose.service" ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = "/bin/sh -c '${pkgs.gnutar}/bin/tar cv --files-from /dev/null | ${pkgs.docker}/bin/docker import - testimg'";
+              TimeoutSec = 90;
+            };
+          };
+
+          # Start an existing service. The managed-docker-compose service should spin this one down.
+          systemd.services.start-existing-docker-container = {
+            description = "Start existing Docker container";
+            after = [ "create-fake-docker-image.service" ];
+            before = [ "managed-docker-compose.service" ];
+            requires = [ "create-fake-docker-image.service" ];
+            requiredBy = [ "managed-docker-compose.service" ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStart = "${pkgs.docker}/bin/docker compose --file /etc/docker-compose/old_app/compose.yaml up --detach --wait";
+              TimeoutSec = 90;
+            };
+          };
+
+          # Run a very lightweight image, but also one that doesn't immediately exit.
+          environment.etc."docker-compose/current_app/compose.yaml".text = 
+            ''
+            services:
+              current_app:
+                image: testimg
+                command: /bin/tail -f /dev/null
+                network_mode: none
+                volumes:
+                  # Map the bin from the current system in so that we can execute `tail`
+                  - /nix/store:/nix/store
+                  - /run/current-system/sw/bin:/bin
+            '';
+
+          # This compose file isn't in the list of current files passed to the systemd service,
+          # so it should be spun down.
+          #
+          # In the future we should only spin do applications that have a specific label (which we add)
+          # so that it's still possible for other services to use Docker Compose, but for now we'll
+          # assume that only managed-docker-compose is running Docker Compose.
+          environment.etc."docker-compose/old_app/compose.yaml".text = 
+            ''
+            services:
+              old_app:
+                image: testimg
+                command: /bin/tail -f /dev/null
+                network_mode: none
+                volumes:
+                  # Map the bin from the current system in so that we can execute `tail`
+                  - /nix/store:/nix/store
+                  - /run/current-system/sw/bin:/bin
+            '';
+        };
+        testScript = ''
+          # Make sure the new application spins up
+          machine.wait_until_succeeds("docker ps --format='{{ .Names }}' | grep 'current_app'", timeout=90)
+
+          # Make sure the old application spins down
+          machine.wait_until_fails("docker ps --format='{{ .Names }}' | grep 'old_app'", timeout=120)
         '';
       };
     });

--- a/script/dockercomposeupdate.py
+++ b/script/dockercomposeupdate.py
@@ -26,6 +26,11 @@ class RealCommandRunner:
             stderr=result.stderr.strip(),
             stdout=result.stdout.strip()
         )
+    
+class RunningContainerInfo:
+    def __init__(self, compose_file_path, project_name):
+        self.compose_file_path = compose_file_path
+        self.project_name = project_name
 
 ### File System
 
@@ -41,7 +46,7 @@ class RealFileSystem:
 ### Application
 
 class Application:
-    def compose_file_for_container(self, container_id, docker_backend, command_runner, file_system):
+    def info_for_container(self, container_id, docker_backend, command_runner, file_system) -> RunningContainerInfo:
         """Find the docker compose file associated with a running container."""
         if not container_id:
             raise ValueError("Usage: compose_file_for_container <container_id>")
@@ -50,89 +55,74 @@ class Application:
             docker_backend,
             "inspect",
             container_id,
-            "--format='{{ index .Config.Labels \"com.docker.compose.project.working_dir\" }}'"
+            "--format={{ index .Config.Labels \"com.docker.compose.project.working_dir\" }}"
         ).stdout
         compose_file = command_runner.run(
             docker_backend,
             "inspect",
             container_id,
-            "--format='{{ index .Config.Labels \"com.docker.compose.project.config_files\" }}'"
+            "--format={{ index .Config.Labels \"com.docker.compose.project.config_files\" }}"
+        ).stdout
+        project_name = command_runner.run(
+            docker_backend,
+            "inspect",
+            container_id,
+            "--format={{ index .Config.Labels \"com.docker.compose.project\" }}"
         ).stdout
 
         if not compose_file.startswith(compose_dir):
             compose_file = os.path.join(compose_dir, compose_file)
 
-        return str(Path(compose_file).resolve()) if file_system.exists(Path(compose_file)) else None
+        compose_file_path = str(Path(compose_file).resolve()) if file_system.exists(Path(compose_file)) else None
+        if compose_file_path == None:
+            return None
 
-    def collect_compose_files_for_running_containers(self, docker_backend, command_runner, file_system):
+        # Return both the compose.yaml path as well as the project name. If only the compose file path is given
+        # then `docker compose down` tries to derive the project from the containing directory name, but with the Nix store
+        # that's likely not the correct project name.
+        return RunningContainerInfo(compose_file_path=compose_file_path, project_name=project_name)            
+
+    def collect_info_for_running_containers(self, docker_backend, command_runner, file_system) -> list[RunningContainerInfo]:
         """Find all compose files for currently running containers."""
 
         container_ids = command_runner.run(docker_backend, "ps", "-q").stdout.splitlines()
-        compose_files = set()
+        container_infos = set()
 
         for container_id in container_ids:
-            compose_file = self.compose_file_for_container(container_id, docker_backend, command_runner, file_system)
-            if compose_file:
-                compose_files.add(compose_file)
+            info = self.info_for_container(container_id, docker_backend, command_runner, file_system)
+            if info:
+                container_infos.add(info)
 
-        return sorted(compose_files)
-
-    def collect_current_compose_files(self, directory: str):
-        """Finds all docker-compose files in a directory, recursively.
-
-        Args:
-            directory (str): The directory to search within.
-
-        Returns:
-            list[Path]: A list of matching file paths.
-        """
-
-        dir = Path(directory)
-        if not dir.is_dir():
-            raise ValueError(f"Provided path '{directory}' is not a valid directory.")
-
-        matches = []
-        patterns = {
-            "compose.yml",
-            "compose.yaml",
-            "container-compose.yml",
-            "container-compose.yaml",
-            "docker-compose.yml",
-            "docker-compose.yaml",
-        }
-
-        for path in dir.walk():
-            for file in path[2]:
-                if file in patterns:
-                    full_path = posixpath.join(path[0], file)
-                    matches.append(str(full_path))
-
-        return sorted(matches)
+        return container_infos
 
 def main():
     parser = argparse.ArgumentParser(description="Update running Docker containers to match the compose files in /etc/docker-compose.")
-    parser.add_argument("docker_backend", help="The Docker command to use ('docker' or 'podman')")
+    parser.add_argument("-b", "--backend", help="The Docker command to use ('docker' or 'podman')")
+    parser.add_argument("-f", "--compose_file", help="The path to a Docker Compose file", nargs="*")
     args = parser.parse_args()
 
-    ETC_DIR = "/etc/docker-compose"
-    print(f"Running docker compose script using {args.docker_backend}")
+    print(f"Running docker compose script using {args.backend}")
 
     app = Application()
     command_runner = RealCommandRunner()
     file_system = RealFileSystem()
 
-    current_compose_files = app.collect_current_compose_files(ETC_DIR)
-    running_compose_files = app.collect_compose_files_for_running_containers(args.docker_backend, command_runner, file_system)
+    current_compose_files = set(args.compose_file)
+    running_container_infos = app.collect_info_for_running_containers(args.backend, command_runner, file_system)
 
-    stale_compose_files = sorted(set(running_compose_files) - set(current_compose_files))
+    # For debugging
+    # print(f"Current files: {current_compose_files}")
+    # print(f"Running files: {set(map(lambda i: i.compose_file_path, running_container_infos))}")
+    
+    stale_containers = filter(lambda i: i.compose_file_path not in current_compose_files, running_container_infos)
 
-    for compose_file in stale_compose_files:
-        print(f"Unloading: {compose_file}")
-        command_runner.run(args.docker_backend, "compose", "--file", compose_file, "down")
+    for container_info in stale_containers:
+        print(f"Unloading: {container_info.compose_file_path}")
+        command_runner.run(args.backend, "compose", "-p", container_info.project_name, "--file", container_info.compose_file_path, "down")
 
     for compose_file in current_compose_files:
         print(f"Loading: {compose_file}")
-        command_runner.run(args.docker_backend, "compose", "--file", compose_file, "up", "--detach")
+        command_runner.run(args.backend, "compose", "--file", compose_file, "up", "--detach")
 
 if __name__ == "__main__":
     main()

--- a/script/tests.py
+++ b/script/tests.py
@@ -26,12 +26,13 @@ class TestDockerComposeUpdate(unittest.TestCase):
     # Test fetching the compose yaml path for a running docker service.
     # This variant tests when docker returns a relative path for the
     # com.docker.compose.project.config_files attribute.
-    def test_compose_file_for_container_with_relative_config_file(self):
+    def test_info_for_container_with_relative_config_file(self):
         command_runner = FakeCommandRunner(
             responses=[
                 CommandRunner.RunResult(returncode=0, stdout="/the/containing/dir"),
                 # Sometimes the config file is returned relative to the working directory
                 CommandRunner.RunResult(returncode=0, stdout="compose.yaml"),
+                CommandRunner.RunResult(returncode=0, stdout="the_project"),
             ]
         )
         file_system = FakeFileSystem(
@@ -39,27 +40,30 @@ class TestDockerComposeUpdate(unittest.TestCase):
         )
 
         app = Application()
-        file_path = app.compose_file_for_container("container_id", "docker", command_runner, file_system)
+        info = app.info_for_container("container_id", "docker", command_runner, file_system)
 
         self.assertEqual(
             command_runner.commands,
             [
-                ("docker", "inspect", "container_id", "--format='{{ index .Config.Labels \"com.docker.compose.project.working_dir\" }}'"),
-                ("docker", "inspect", "container_id", "--format='{{ index .Config.Labels \"com.docker.compose.project.config_files\" }}'"),
+                ("docker", "inspect", "container_id", "--format={{ index .Config.Labels \"com.docker.compose.project.working_dir\" }}"),
+                ("docker", "inspect", "container_id", "--format={{ index .Config.Labels \"com.docker.compose.project.config_files\" }}"),
+                ("docker", "inspect", "container_id", "--format={{ index .Config.Labels \"com.docker.compose.project\" }}"),
             ]
         )
 
-        self.assertEqual(file_path, "/the/containing/dir/compose.yaml")
+        self.assertEqual(info.compose_file_path, "/the/containing/dir/compose.yaml")
+        self.assertEqual(info.project_name, "the_project")
 
     # Test fetching the compose yaml path for a running docker service.
     # This variant tests when docker returns an absolute path for the
     # com.docker.compose.project.config_files attribute.
-    def test_compose_file_for_container_with_absolute_config_file(self):
+    def test_info_for_container_with_absolute_config_file(self):
         command_runner = FakeCommandRunner(
             responses=[
                 CommandRunner.RunResult(returncode=0, stdout="/the/containing/dir"),
                 # Sometimes the config file is returned as an absolute path
                 CommandRunner.RunResult(returncode=0, stdout="/the/containing/dir/compose.yaml"),
+                CommandRunner.RunResult(returncode=0, stdout="the_project"),
             ]
         )
         file_system = FakeFileSystem(
@@ -67,17 +71,19 @@ class TestDockerComposeUpdate(unittest.TestCase):
         )
 
         app = Application()
-        file_path = app.compose_file_for_container("container_id", "docker", command_runner, file_system)
+        info = app.info_for_container("container_id", "docker", command_runner, file_system)
 
         self.assertEqual(
             command_runner.commands,
             [
-                ("docker", "inspect", "container_id", "--format='{{ index .Config.Labels \"com.docker.compose.project.working_dir\" }}'"),
-                ("docker", "inspect", "container_id", "--format='{{ index .Config.Labels \"com.docker.compose.project.config_files\" }}'"),
+                ("docker", "inspect", "container_id", "--format={{ index .Config.Labels \"com.docker.compose.project.working_dir\" }}"),
+                ("docker", "inspect", "container_id", "--format={{ index .Config.Labels \"com.docker.compose.project.config_files\" }}"),
+                ("docker", "inspect", "container_id", "--format={{ index .Config.Labels \"com.docker.compose.project\" }}"),
             ]
         )
 
-        self.assertEqual(file_path, "/the/containing/dir/compose.yaml")
+        self.assertEqual(info.compose_file_path, "/the/containing/dir/compose.yaml")
+        self.assertEqual(info.project_name, "the_project")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This changes from reading the files in /etc/docker-compose/*/compose.yaml to instead explicitly defining each Docker Compose application in the Nix config. This change makes things less magic, and also allows for specifying additional parameters for each file/application.

The config syntax looks something like:

```
services.managed-docker-compose.applications.test_app = {
  compose_file = "/etc/docker-compose/test_app/docker-compose.yaml";
};
```