### PR TITLE
Fix parsing of repeated compose file arguments

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -198,7 +198,7 @@
         };
         testScript = ''
           # Make sure the new application spins up
-          machine.wait_until_succeeds("docker ps --format='{{ .Names }}' | grep 'current_app'", timeout=90)
+          machine.wait_until_succeeds("docker ps --format='{{ .Names }}' | grep 'current_app'", timeout=120)
 
           # Make sure the old application spins down
           machine.wait_until_fails("docker ps --format='{{ .Names }}' | grep 'old_app'", timeout=120)

--- a/script/dockercomposeupdate.py
+++ b/script/dockercomposeupdate.py
@@ -98,7 +98,7 @@ class Application:
 def main():
     parser = argparse.ArgumentParser(description="Update running Docker containers to match the compose files in /etc/docker-compose.")
     parser.add_argument("-b", "--backend", help="The Docker command to use ('docker' or 'podman')")
-    parser.add_argument("-f", "--compose_file", help="The path to a Docker Compose file", nargs="*")
+    parser.add_argument("-f", "--compose_file", help="The path to a Docker Compose file", action='append')
     args = parser.parse_args()
 
     print(f"Running docker compose script using {args.backend}")


### PR DESCRIPTION
We were incorrectly allowing the -f argument to have multiple parts, but what we really wanted was allowing that argument to be repeated multiple times.