### PR TITLE
Extract substitution logic to its own file

### DIFF
--- a/resolve-substitutions.nix
+++ b/resolve-substitutions.nix
@@ -1,0 +1,7 @@
+template: substitutions:
+let
+  keys = builtins.attrNames substitutions;
+  wrappedKeys = map (k: "@${k}@") keys;
+  values = builtins.attrValues substitutions;
+in
+  builtins.replaceStrings wrappedKeys values template


### PR DESCRIPTION
And also do it in multiple pieces. Rather than using pkgs.substituteAll, we manually read the file contents, do the replacement, then write the contents back out to another file. This has two advantages:
 1. It stops using pkgs.substituteAll, which could go away at some point (https://github.com/NixOS/nixpkgs/issues/237216)
 2. It allows us to do multiple passes on the content in the future, without creating intermediary files.