### PR TITLE
Remove container-related service enable calls

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -78,10 +78,8 @@ in {
     # Give system the right packages, including our own
     environment.systemPackages = [ managedDockerCompose ] ++ envSysPackages;
 
-    # Setup the right virtualisation modules depending on backend.
-    virtualisation.docker.enable = mkIf (backendStr == "docker") true;
+    # Enable the container service if we're running Docker. Podman doesn't need it.
     virtualisation.containers.enable = mkIf (backendStr == "docker") true;
-    virtualisation.podman.enable = mkIf (backendStr == "podman") true;
 
     # Do some file system setup. This must be done in an activation script when we have
     # root access and can still modify certain things.


### PR DESCRIPTION
These were unnecessary and were creating duplicate dependencies on podman or docker, which manifested as collisions:

```
building '/nix/store/951wc2azdq01lxir72ap951xrkd1l15c-system-path.drv'...
system-path> warning: collision between /nix/store/nw60jgncj34zh9l2qrzr1m95c2f9r8i4-podman-5.2.3/share/bash-completion/completions/podman' and /nix/store/17rf8wck240qxs86j7l9v145phync5iy-podman-5.2.3/share/bash-completion/completions/podman'
```