### PR TITLE
Fix Docker Compose spin down

### DIFF
--- a/module.nix
+++ b/module.nix
@@ -13,22 +13,12 @@ let
     else throw "Invalid docker compose backend: ${cfg.backend}";
 
   envSysPackages = if backendStr == "podman" then [
-    pkgs.python3
     pkgs.podman
     pkgs.podman-compose
   ] else [
-    pkgs.python3
     pkgs.docker
     pkgs.docker-compose
   ];
-
-  resolvedComposeFilesDirectory = "/run/nix-docker-compose";
-
-  # Write the config options out to a JSON file, which will then be read by the Python script.
-  configFile = pkgs.writeTextFile {
-    name = "managed-docker-compose-config.json";
-    text = (builtins.toJSON cfg);
-  };
 in {
   options.services.managedDockerCompose = rec {
     enable = mkEnableOption "Enable automatic docker compose file management.";
@@ -83,36 +73,29 @@ in {
     virtualisation.containers.enable = mkIf (backendStr == "docker") true;
     virtualisation.podman.enable = mkIf (backendStr == "podman") true;
 
-    # Do some file system setup. This must be done in an activation script when we have
-    # root access and can still modify certain things.
-    system.activationScripts."managed-docker-compose" = {
-      text = ''
-        # Delete the old compose files, which may contain secrets.
-        # We'll recreate them if they're still valid.
-        rm -rf "${resolvedComposeFilesDirectory}/*"
-
-        mkdir -p "${resolvedComposeFilesDirectory}"
-        chmod 0751 "${resolvedComposeFilesDirectory}"
-
-        # Create a RAM disk to ensure the secrets don't survive a reboot and aren't
-        # available to someone sniffing the hard drive.
-        # If this package is still included then we'll recreate them.
-        grep -q "${resolvedComposeFilesDirectory} ramfs" /proc/mounts ||
-          mount -t ramfs none "${resolvedComposeFilesDirectory}" -o nodev,nosuid,mode=0751
-      '';
-    };
-
     # Run the docker-compose-update.py script each time we activate/deploy.
     systemd.services.managed-docker-compose = {
       description = "Update Docker Compose files as part of nix config";
       wantedBy = [ "multi-user.target" ];
-      path = envSysPackages;
+      path = with pkgs; [ python3 ] ++ envSysPackages;
       serviceConfig = let
-        composeFileArgs = (map (file: "-f \"${lib.escapeShellArg file}\"") composeFiles);
-        combinedArgs = concatStringsSep " " composeFileArgs;
+        # Write the config options out to a JSON file, which will then be read by the Python script.
+        configFile = pkgs.writeTextFile {
+          name = "managed-docker-compose-config.json";
+          text = (builtins.toJSON cfg);
+        };
+
+        resolvedFilesDirectoryName = "nix-docker-compose";
       in {
+        # systemd will auto-create /run/${resolvedFilesDirectoryName}
+        RuntimeDirectory = resolvedFilesDirectoryName;
+        RuntimeDirectoryMode = 751;
+        RuntimeDirectoryPreserve = "yes";
         Type = "simple";
-        ExecStart = "${managedDockerCompose}/bin/managed-docker-compose -c ${configFile} -o ${resolvedComposeFilesDirectory}";
+        # Resolve substitutions and secrets, and start/stop Docker Compose projects
+        ExecStart = ''
+          ${managedDockerCompose}/bin/managed-docker-compose -c ${configFile} -o "/run/${resolvedFilesDirectoryName}"
+        '';
         TimeoutSec = 90;
       };
     };

--- a/script/src/docker_utils.py
+++ b/script/src/docker_utils.py
@@ -4,7 +4,7 @@ from file_system import FileSystem
 from pathlib import Path
 
 class RunningContainerInfo:
-    def __init__(self, compose_file_path, project_name):
+    def __init__(self, compose_file_path: Path, project_name: str):
         self.compose_file_path = compose_file_path
         self.project_name = project_name
 
@@ -41,7 +41,7 @@ class DockerUtils:
         if not compose_file.startswith(compose_dir):
             compose_file = os.path.join(compose_dir, compose_file)
 
-        compose_file_path = str(Path(compose_file).resolve()) if self.file_system.exists(Path(compose_file)) else None
+        compose_file_path = Path(compose_file).resolve() if self.file_system.exists(Path(compose_file)) else None
         if compose_file_path == None:
             return None
 
@@ -62,7 +62,7 @@ class DockerUtils:
                 container_infos.add(info)
 
         return container_infos
-    
+
     def compose_down(self, info: RunningContainerInfo):
         self.command_runner.run(self.docker_backend, "compose", "-p", info.project_name, "--file", info.compose_file_path, "down")
 

--- a/script/src/main.py
+++ b/script/src/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import json
+import shutil
 import sys
 from command_runner import RealCommandRunner
 from docker_utils import DockerUtils
@@ -26,7 +27,8 @@ def main():
     backend = data.get("backend")
     projects = dict(data.get("projects"))
 
-    substituter = Substituter(file_system=file_system, output_dir=Path(args.output_dir))
+    output_dir = Path(args.output_dir)
+    substituter = Substituter(file_system=file_system, output_dir=output_dir)
     current_compose_files = set()
     for name, app_config in projects.items():
         resolved_path = substituter.substitute(
@@ -48,16 +50,33 @@ def main():
     # For debugging
     # print(f"Current files: {current_compose_files}")
     # print(f"Running files: {set(map(lambda i: i.compose_file_path, running_container_infos))}")
-    
+
     stale_containers = filter(lambda i: i.compose_file_path not in current_compose_files, running_container_infos)
 
     for container_info in stale_containers:
         print(f"Unloading: {container_info.compose_file_path}")
         docker_utils.compose_down(info=container_info)
 
+        # Delete the old compose file as it contained secrets and we don't want to leave it around.
+        clean_up_compose_file(container_info.compose_file_path, output_dir)
+
     for compose_file in current_compose_files:
         print(f"Loading: {compose_file}")
         docker_utils.compose_up(path=compose_file)
+
+def clean_up_compose_file(compose_file_path: Path, output_dir: Path):
+    try:
+        compose_file_path.resolve().relative_to(output_dir.resolve())
+    except ValueError:
+        # The compose file is not within the secrets directory, so don't try to delete it.
+        # Compose files that didn't include substitutions are kept in the Nix store, which we can't
+        # (and shouldn't) modify.
+        return
+
+    try:
+        shutil.rmtree(str(compose_file_path.parent))
+    except Exception as e:
+        print(f"❌ Failed to delete {compose_file_path.parent}: {e}")
 
 if __name__ == "__main__":
     main()

--- a/script/src/substituter.py
+++ b/script/src/substituter.py
@@ -1,4 +1,5 @@
 import os
+import hashlib
 from file_system import FileSystem
 from pathlib import Path
 from typing import Dict
@@ -31,7 +32,11 @@ class Substituter:
             template = template.replace(f"${{{key}}}", secret_content)
 
         # Write to output file
-        project_dir = self.output_dir / project_name
+        # Include a hash of the contents so that if we change a compose file, the old one is still
+        # there to spin down even after the new one has been spun up.
+        sha256 = hashlib.sha256(template.encode('utf-8')).digest()
+
+        project_dir = self.output_dir / f"{sha256}-{project_name}"
         project_dir.mkdir()
         output_path = project_dir / "compose.yml"
         output_path.write_text(template)

--- a/script/tests/tests.py
+++ b/script/tests/tests.py
@@ -35,7 +35,7 @@ class TestDockerComposeUpdate(unittest.TestCase):
             ]
         )
 
-        self.assertEqual(info.compose_file_path, "/the/containing/dir/compose.yaml")
+        self.assertEqual(info.compose_file_path, Path("/the/containing/dir/compose.yaml"))
         self.assertEqual(info.project_name, "the_project")
 
     # Test fetching the compose yaml path for a running docker service.
@@ -66,7 +66,7 @@ class TestDockerComposeUpdate(unittest.TestCase):
             ]
         )
 
-        self.assertEqual(info.compose_file_path, "/the/containing/dir/compose.yaml")
+        self.assertEqual(info.compose_file_path, Path("/the/containing/dir/compose.yaml"))
         self.assertEqual(info.project_name, "the_project")
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Avoid overwriting old Compose files for the same project by adding a SHA256 hash to the file name
- Delete the old files only after spinning the service down, not before