### PR TITLE
Increase timeout for docker compose down

### DIFF
--- a/script/src/docker_utils.py
+++ b/script/src/docker_utils.py
@@ -64,7 +64,7 @@ class DockerUtils:
         return container_infos
 
     def compose_down(self, info: RunningContainerInfo):
-        self.command_runner.run(self.docker_backend, "compose", "-p", info.project_name, "--file", info.compose_file_path, "down")
+        self.command_runner.run(self.docker_backend, "compose", "-p", info.project_name, "--file", info.compose_file_path, "down", "--timeout", "120")
 
     def compose_up(self, path: str):
         self.command_runner.run(self.docker_backend, "compose", "--file", path, "up", "--detach")


### PR DESCRIPTION
The default timeout is 10s when waiting for services to stop via `docker compose down`. Services often took longer than this, which led to us returning from the command early, and then prematurely deleting the compose YAML file. The command still finished in the background, but now errored out with a "compose file at path not found" error.