### PR TITLE
Rename secrets to substitutionsFromFiles

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1736669804,
-        "narHash": "sha256-EZusd5yhiZLXdBUDtXB3wCX3QvBeSFx/N0AstaajzpU=",
+        "lastModified": 1750005367,
+        "narHash": "sha256-h/aac1dGLhS3qpaD2aZt25NdKY7b+JT0ZIP2WuGsJMU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "87d46406d6280e1c064bc5df10ebd09ce3113cb3",
+        "rev": "6c64dabd3aa85e0c02ef1cdcb6e1213de64baee3",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-24.11-small",
+        "ref": "nixos-25.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "A nix service that runs docker-compose.yaml files included in your nix config repo.";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-24.11-small";
+    nixpkgs.url = "nixpkgs/nixos-25.05";
     flake-utils.url = "github:numtide/flake-utils";
   };
 

--- a/module.nix
+++ b/module.nix
@@ -49,10 +49,14 @@ in {
             };
           };
 
-          secrets = mkOption {
+          substitutionsFromFiles = mkOption {
             type = types.attrsOf types.path;
             default = {};
-            description = "Attribute set of variable substitutions to apply to Docker Compose files. For example, ${dbPassword} in compose.yaml will be replaced by the contents of the file specified by secrets.dbPassword.";
+            description = ''
+            Attribute set of variable substitutions to apply to Docker Compose files, with each value loaded from a file.
+            
+            For example, ${dbPassword} in compose.yaml will be replaced by the contents of the file specified by substitutionsFromFiles.dbPassword.
+            '';
             example = {
               dbPassword = "/etc/db_password";
             };
@@ -92,7 +96,7 @@ in {
         RuntimeDirectoryMode = 751;
         RuntimeDirectoryPreserve = "yes";
         Type = "simple";
-        # Resolve substitutions and secrets, and start/stop Docker Compose projects
+        # Resolve substitutions and substitutionsFromFiles, and start/stop Docker Compose projects
         ExecStart = ''
           ${managedDockerCompose}/bin/managed-docker-compose -c ${configFile} -o "/run/${resolvedFilesDirectoryName}"
         '';

--- a/script/src/main.py
+++ b/script/src/main.py
@@ -35,7 +35,7 @@ def main():
             path=Path(app_config.get("composeFile")),
             project_name=name,
             substitutions=app_config.get("substitutions"),
-            secrets=app_config.get("secrets")
+            substitutionsFromFiles=app_config.get("substitutionsFromFiles")
         )
         current_compose_files.add(resolved_path)
 
@@ -57,7 +57,7 @@ def main():
         print(f"Unloading: {container_info.compose_file_path}")
         docker_utils.compose_down(info=container_info)
 
-        # Delete the old compose file as it contained secrets and we don't want to leave it around.
+        # Delete the old compose file as it may have contained secrets (substitutionsFromFiles) and we don't want to leave it around.
         clean_up_compose_file(container_info.compose_file_path, output_dir)
 
     for compose_file in current_compose_files:

--- a/script/src/substituter.py
+++ b/script/src/substituter.py
@@ -10,12 +10,12 @@ class Substituter:
         self.file_system = file_system
         self.output_dir = output_dir
 
-    def substitute(self, path: Path, project_name: str, substitutions: Dict[str, str], secrets: Dict[str, str]) -> Path:
+    def substitute(self, path: Path, project_name: str, substitutions: Dict[str, str], substitutionsFromFiles: Dict[str, str]) -> Path:
         if not path.exists():
             raise Exception(f"Compose file not found: {path}")
 
         # If we're not doing any substitutions, then don't write out a new file.
-        if not substitutions and not secrets:
+        if not substitutions and not substitutionsFromFiles:
             return path
 
         template = path.read_text()
@@ -24,8 +24,8 @@ class Substituter:
         for key, value in substitutions.items():
             template = template.replace(f"${{{key}}}", value)
 
-        # Apply secrets
-        for key, secret_path in secrets.items():
+        # Apply substitutionsFromFiles (secrets)
+        for key, secret_path in substitutionsFromFiles.items():
             secret_file = Path(secret_path)
             if not secret_file.exists():
                 raise Exception(f"Secret file not found: {secret_path}")

--- a/tests/tests.nix
+++ b/tests/tests.nix
@@ -219,7 +219,7 @@ in {
           substitutions = {
             subbed = "test";
           };
-          secrets = {
+          substitutionsFromFiles = {
             secret = "/etc/secretpassword";
           };
         };


### PR DESCRIPTION
The 'secrets' name was confusing, as most secrets should not actually be loaded using this method as it's a last resort and less secure than leaving the secrets in a file directly (vs. loading them into the Compose file).